### PR TITLE
Update EAG language extension to 2.0.x

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,14 @@
 vscode:
   extensions:
-    - webfreak.code-d@0.22.0:K65wBqeoqTvGoea7XwBc+A==
+    - webfreak.code-d
 
-    - grammarcraft.epsilon-eag@1.3.1:JAkmvSR34A43N5i6a7Ta1g==
+    - grammarcraft.epsilon-eag-extension-pack@2.0.3
 
-    - grammarcraft.epsilon-eag-light-theme@1.3.1:+tZqoYgugeF8cnHdx/Hn9A==
+    - grammarcraft.epsilon-eag@2.0.3
 
-    - grammarcraft.epsilon-eag-dark-theme@1.3.1:z88q0tJdAJbxKuArWkn8Og==
+    - grammarcraft.epsilon-eag-dark-theme@2.0.3
+
+    - grammarcraft.epsilon-eag-light-theme@2.0.3
 
 image:
   file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,4 +14,7 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: dub test
+  - name: Run tests
+    init: dub test
+  - name: Compile gamma
+    init: dub build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "eag.runCompilerGenerator": true,
+    "eag.compilerGenerator.additionalExeOptions": "-s",
+    "eag.compilerGenerator.codeGenerationOnly": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "eag.runCompilerGenerator": true,
     "eag.compilerGenerator.additionalExeOptions": "-s",
-    "eag.compilerGenerator.codeGenerationOnly": false
+    "eag.compilerGenerator.codeGenerationOnly": false,
+    "workbench.colorTheme": "EAG (dark)"
 }


### PR DESCRIPTION
- bumped EAG extensions to version 2.0.3 for Gitpod which is capable to start the compiler generator on file saving and show compiler generator errors on the VS Code problem view
- pre-compile gamma when starting Gitpod
- let the Gamma compiler generator being invoked on .eag file saving to show errors or generate and compile the compiler
- makes EAG (dark) the default theme