### PR TITLE
Report errors for unproductive nonterminals (GH issue #1)

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -25,6 +25,17 @@
             "name": "example",
             "sourcePaths": ["test"],
             "importPaths": ["test"],
+            "excludedSourceFiles": ["test/issues/*.d"],
+            "preBuildCommands": ["$DUB build"],
+            "dependencies": {
+                "silly": ">=1.0.2"
+            }
+        },
+        {
+            "name": "issues",
+            "sourcePaths": ["test/issues"],
+            "sourceFiles": ["test/helper.d"],
+            "importPaths": ["test"],
             "preBuildCommands": ["$DUB build"],
             "dependencies": {
                 "silly": ">=1.0.2"

--- a/src/epsilon/analyzer.d
+++ b/src/epsilon/analyzer.d
@@ -8,7 +8,6 @@ import log;
 import runtime;
 import std.bitmanip : BitArray;
 import std.conv : to;
-import epsilon.main : Arguments;
 
 const nil = EAG.nil;
 int ErrorCounter;
@@ -962,7 +961,7 @@ void ComputeEAGSets()
     EAG.Prod = Prod;
 }
 
-void Analyse(Input input, const Arguments arguments)
+void Analyse(Input input)
 {
     EAG.Init;
     lexer = Lexer(input, EAG.symbolTable);
@@ -981,7 +980,7 @@ void Analyse(Input input, const Arguments arguments)
     }
     if (ErrorCounter == 0)
     {
-        CheckForUnproductiveNonterminals(arguments);
+        CheckForUnproductiveNonterminals;
     } 
     if (ErrorCounter == 0)
     {
@@ -998,34 +997,25 @@ void Analyse(Input input, const Arguments arguments)
     }
 }
 
-void CheckForUnproductiveNonterminals(const Arguments arguments)
+void CheckForUnproductiveNonterminals()
 {
     const Unprod = EAG.All - EAG.Prod;
-    for (int Sym = EAG.firstHNont; Sym < EAG.NextHNont; ++Sym)
-    {
-        if (Unprod[Sym])
-        {
-            if (EAG.HNont[Sym].anonymous) {
-                if (arguments.ignoreNonproductiveNonterminals) {
-                    warn!"anonymous nonterminal in %s unproductive"(EAG.NamedHNontRepr(Sym));
-                }
-                else {
-                    ErrorCounter++;
-                    error!"anonymous nonterminal in %s unproductive"(EAG.NamedHNontRepr(Sym));
-                }
-            }
-            else {
-                if (arguments.ignoreNonproductiveNonterminals) {
-                    warn!"%s unproductive"(EAG.HNontRepr(Sym));
-                }
-                else {
-                    ErrorCounter++;
-                    error!"%s unproductive"(EAG.HNontRepr(Sym));
-                }
-            }
-        }
+
+    if (Unprod[EAG.StartSym]) {
+        ErrorCounter++;
+        error!"start symbol %s is unproductive"(EAG.HNontRepr(EAG.StartSym));
     }
 
+    for (int Sym = EAG.firstHNont; Sym < EAG.NextHNont; ++Sym)
+    {
+        if (Unprod[Sym] && Sym != EAG.StartSym)
+        {
+            if (EAG.HNont[Sym].anonymous)
+                warn!"anonymous nonterminal in %s unproductive"(EAG.NamedHNontRepr(Sym));
+            else
+                warn!"%s unproductive"(EAG.HNontRepr(Sym));
+        }
+    }
 }
 
 void CheckForUnreachableNonterminals()

--- a/src/epsilon/analyzer.d
+++ b/src/epsilon/analyzer.d
@@ -883,16 +883,10 @@ void ComputeEAGSets()
         }
     }
 
-    long Warnings = 0;
-
     EAG.Reach = BitArray();
     EAG.Reach.length = EAG.NextHNont + 1;
 
     ComputeReach(EAG.StartSym);
-    // count warnings for unreachable non-terminals
-    for (int Sym = EAG.firstHNont; Sym < EAG.NextHNont; ++Sym)
-        if (EAG.HNont[Sym].Def !is null && !EAG.Reach[Sym] && EAG.HNont[Sym].Id >= 0)
-            ++Warnings;
     Deg = new int[EAG.NextHAlt];
     Stack = new int[EAG.NextHNont];
     Top = 0;
@@ -965,10 +959,6 @@ void ComputeEAGSets()
     }
     Prune;
     EAG.Prod = Prod;
-    // count warnings for unproductive non-terminals
-    Warnings += (EAG.All & ~EAG.Prod).count;
-    if (Warnings > 0)
-        warn!"%s warnings"(Warnings);
 }
 
 void Analyse(Input input)

--- a/src/epsilon/main.d
+++ b/src/epsilon/main.d
@@ -68,7 +68,8 @@ static struct Arguments
     @(NamedArgument.Description("Show error positions language-server friendly as offsets"))
     bool offset;
 
-    @(NamedArgument("ignore-nonproductive").Description("Ignore non-productive non-terminals and force code generation"))
+    @(NamedArgument("ignore-nonproductive")
+        .Description("Ignore non-productive non-terminals and force code generation"))
     bool ignoreNonproductiveNonterminals;
 
 }

--- a/src/epsilon/main.d
+++ b/src/epsilon/main.d
@@ -67,6 +67,10 @@ static struct Arguments
 
     @(NamedArgument.Description("Show error positions language-server friendly as offsets"))
     bool offset;
+
+    @(NamedArgument("ignore-nonproductive").Description("Ignore non-productive non-terminals and force code generation"))
+    bool ignoreNonproductiveNonterminals;
+
 }
 
 void command(Arguments arguments)
@@ -130,11 +134,11 @@ void compile(Input input, const Arguments arguments)
 
     const settings = createSettings(arguments);
 
-    analyzer.Analyse(input);
+    analyzer.Analyse(input, arguments);
 
     enforce(analyzer.ErrorCounter == 0);
 
-    analyzer.Warnings;
+    analyzer.CheckForUnreachableNonterminals;
     Predicates.Check;
 
     ELL1Gen.Test(settings);

--- a/src/epsilon/main.d
+++ b/src/epsilon/main.d
@@ -67,11 +67,6 @@ static struct Arguments
 
     @(NamedArgument.Description("Show error positions language-server friendly as offsets"))
     bool offset;
-
-    @(NamedArgument("ignore-nonproductive")
-        .Description("Ignore non-productive non-terminals and force code generation"))
-    bool ignoreNonproductiveNonterminals;
-
 }
 
 void command(Arguments arguments)
@@ -135,7 +130,7 @@ void compile(Input input, const Arguments arguments)
 
     const settings = createSettings(arguments);
 
-    analyzer.Analyse(input, arguments);
+    analyzer.Analyse(input);
 
     enforce(analyzer.ErrorCounter == 0);
 

--- a/test/helper.d
+++ b/test/helper.d
@@ -57,3 +57,15 @@ Result shouldFail(Result result, string pattern)
     }
     return result;
 }
+
+Result shouldFailNotMatching(Result result, string pattern)
+{
+    import std.regex : matchFirst, regex;
+
+    with (result)
+    {
+        assert(status != 0, output);
+        assert(!output.matchFirst(regex(pattern, "m")), output);
+    }
+    return result;
+}

--- a/test/issues/issue-gh-1-warn-only.eag
+++ b/test/issues/issue-gh-1-warn-only.eag
@@ -1,0 +1,19 @@
+// copied from example/bnf/expr.eag and modified 
+
+Code = Code Code "ADD" | Number "ENTER".
+
+Expr <+ Code2>:
+    Term <Code1> ExprTail<Code1, Code2>.
+Expr <+ "0" "ENTER": Code>: 'making' 'Expr' 'productive'.
+
+ExprTail<- Code1, + Code3>:
+    "+" Term<Code2> ExprTail<Code1 Code2 "ADD", Code3>.
+// ExprTail<- Code, + Code>: .
+
+Term <+ Number "ENTER": Code>:
+    number <Number>.
+
+Number = "0" | "1".
+
+number: <+ "0": Number> "0".
+number: <+ "1": Number> "1".

--- a/test/issues/issue-gh-1.d
+++ b/test/issues/issue-gh-1.d
@@ -2,12 +2,23 @@ module test.issues.issue_gh_1;
 
 import test.helper;
 
-@("test for GH issue #1")
+@("test GH issue #1 for unproductive start symbol")
 unittest
 {
     with (sandbox)
     {
         run!"cat test/issues/issue-gh-1.eag | ./gamma --output-directory %s"(directory)
-            .shouldFailNotMatching("Error: undefined identifier P0");
+            .shouldFailNotMatching("Error: undefined identifier P0")
+            .shouldFail("error: start symbol Expr is unproductive");
+    }
+}
+
+@("test GH issue #1 for unproductive non-start symbol")
+unittest
+{
+    with (sandbox)
+    {
+        run!"cat test/issues/issue-gh-1-warn-only.eag | ./gamma --output-directory %s"(directory)
+            .shouldMatch("warn: ExprTail unproductive");
     }
 }

--- a/test/issues/issue-gh-1.d
+++ b/test/issues/issue-gh-1.d
@@ -1,0 +1,13 @@
+module test.issues.issue_gh_1;
+
+import test.helper;
+
+@("test for GH issue #1")
+unittest
+{
+    with (sandbox)
+    {
+        run!"cat test/issues/issue-gh-1.eag | ./gamma --output-directory %s"(directory)
+            .shouldFailNotMatching("Error: undefined identifier P0");
+    }
+}

--- a/test/issues/issue-gh-1.eag
+++ b/test/issues/issue-gh-1.eag
@@ -1,0 +1,18 @@
+// copied from example/bnf/expr.eag and modified 
+
+Code = Code Code "ADD" | Number "ENTER".
+
+Expr <+ Code2>:
+    Term <Code1> ExprTail<Code1, Code2>.
+
+ExprTail<- Code1, + Code3>:
+    "+" Term<Code2> ExprTail<Code1 Code2 "ADD", Code3>.
+//ExprTail<- Code, + Code>: .
+
+Term <+ Number "ENTER": Code>:
+    number <Number>.
+
+Number = "0" | "1".
+
+number: <+ "0": Number> "0".
+number: <+ "1": Number> "1".


### PR DESCRIPTION
Hi @linkrope, tried to solve the issue #1.
First real D programming! :smile: 

I added a new option _--ignore-nonproductive_ to force the code generation even if there are non-productive non-terminals for mimic the behavior we had before. 
Not sure, whether it is better to pass `Arguments` as argument down as `Analyze()` or only the boolean value of the option. Please advice. 

I also renamed the `Warning()` method as now it covers the determination of unreachable non-terminals only. 