### PR TITLE
Added recognition of EOF at LL(1) parsers.

### DIFF
--- a/fix/epsilon/ell1gen.fix.d
+++ b/fix/epsilon/ell1gen.fix.d
@@ -253,19 +253,19 @@ void Compile(Input input, bool info_, bool verbose, bool write)
         S.Init(input);
         S.Get(Tok);
         $(V1);
-        recognizeEof;
+        recognizeEnd;
         $
     }
 }
 
-private void recognizeEof() 
+private void recognizeEnd() 
 {
     while (Tok == sepTok)
         S.Get(Tok);
     if (Tok != endTok)
     {
         ++ErrorCounter;
-        error!"syntax error, unexpected content before end of file\n%s"(S.Pos);
+        error!"syntax error, unexpected content before end of file (or end of text)\n%s"(S.Pos);
     }
 }
 

--- a/test/ell1.d
+++ b/test/ell1.d
@@ -26,7 +26,8 @@ unittest
         run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
             .shouldPassWith("NoEOF grammar is SLAG");
         run!"cd %s && echo x yy zzz | ./NoEOF"(directory)
-            .shouldFailWith("syntax error, unexpected token\\(s\\) before end of file");    }
+            .shouldFailWith("syntax error, unexpected token\\(s\\) before end of file");
+    }
 }
 
 @("issue #11: allow trailing content before EOF at LL(1) parser if option -t has been passeed")

--- a/test/ell1.d
+++ b/test/ell1.d
@@ -13,19 +13,23 @@ unittest
     }
 }
 
-@("issue #11: disallow trailing content before EOF at LL(1) parser, by default")
+@("issue #11: ensure trailing content before EOF is reported as syntax error by LL(1) parser")
 unittest
 {
     with (sandbox)
     {
         const eag = `
-            NoEOF<+ 'Done': Done>: 'x'.
-            Done = 'Done'.
+            N = | '1' N.
+
+            S<+  : N>:
+                .
+            S<+ '1' N: N>: 
+                'a' S<N> 'b'.
             `.outdent;
 
         run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
-            .shouldPassWith("NoEOF grammar is SLAG");
-        run!"cd %s && echo x yy zzz | ./NoEOF"(directory)
+            .shouldPassWith("S grammar is SLAG");
+        run!"cd %s && echo aa bbb | ./S"(directory)
             .shouldFailWith("error: syntax error, unexpected content before end of file");
     }
 }

--- a/test/ell1.d
+++ b/test/ell1.d
@@ -1,5 +1,6 @@
 module test.ell1;
 
+import std.string;
 import test.helper;
 
 @("compile left-recursion.eag")
@@ -9,5 +10,38 @@ unittest
     {
         run!"./gamma example/left-recursion.eag --output-directory %s"(directory)
             .shouldFailWith("left recursion");
+    }
+}
+
+@("issue #11: disallow trailing content before EOF at LL(1) parser, by default")
+unittest
+{
+    with (sandbox)
+    {
+        const eag = `
+            NoEOF<+ 'Done': Done>: 'x'.
+            Done = 'Done'.
+            `.outdent;
+
+        run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
+            .shouldPassWith("NoEOF grammar is SLAG");
+        run!"cd %s && echo x yy zzz | ./NoEOF"(directory)
+            .shouldFailWith("syntax error, unexpected token\\(s\\) before end of file");    }
+}
+
+@("issue #11: allow trailing content before EOF at LL(1) parser if option -t has been passeed")
+unittest
+{
+    with (sandbox)
+    {
+        const eag = `
+            NoEOF<+ 'Done': Done>: 'x'.
+            Done = 'Done'.
+            `.outdent;
+
+        run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
+            .shouldPassWith("NoEOF grammar is SLAG");
+        run!"cd %s && echo x yy zzz | ./NoEOF -t"(directory)
+            .shouldPassWith("Done");
     }
 }

--- a/test/ell1.d
+++ b/test/ell1.d
@@ -30,6 +30,6 @@ unittest
         run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
             .shouldPassWith("S grammar is SLAG");
         run!"cd %s && echo aa bbb | ./S"(directory)
-            .shouldFailWith("error: syntax error, unexpected content before end of file");
+            .shouldFailWith("syntax error, unexpected content before end of file");
     }
 }

--- a/test/ell1.d
+++ b/test/ell1.d
@@ -26,23 +26,6 @@ unittest
         run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
             .shouldPassWith("NoEOF grammar is SLAG");
         run!"cd %s && echo x yy zzz | ./NoEOF"(directory)
-            .shouldFailWith("syntax error, unexpected token\\(s\\) before end of file");
-    }
-}
-
-@("issue #11: allow trailing content before EOF at LL(1) parser if option -t has been passeed")
-unittest
-{
-    with (sandbox)
-    {
-        const eag = `
-            NoEOF<+ 'Done': Done>: 'x'.
-            Done = 'Done'.
-            `.outdent;
-
-        run!"cat <<EOF | ./gamma --output-directory %s%sEOF"(directory, eag)
-            .shouldPassWith("NoEOF grammar is SLAG");
-        run!"cd %s && echo x yy zzz | ./NoEOF -t"(directory)
-            .shouldPassWith("Done");
+            .shouldFailWith("error: syntax error, unexpected content before end of file");
     }
 }

--- a/test/oberon0.d
+++ b/test/oberon0.d
@@ -11,11 +11,11 @@ unittest
     {
         run!"./gamma example/frontend.eag --output-directory %s"(directory)
             .shouldPassWith("OberonO grammar is SLAG");
-        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
             .shouldPassWith("^done$");
-        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
+        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
             .shouldPassWith("^done$");
-        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Error.Mod"))
+        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Error.Mod"))
             .shouldFailWith("^info: errors detected: 31$");
     }
 }
@@ -28,11 +28,11 @@ static foreach (eag; ["oberon0.eag", "unequal.eag"])
         {
             run!"./gamma --space example/%s --output-directory %s"(eag, directory)
                 .shouldPassWith("OberonO grammar is SLAG");
-            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
                 .shouldPassWith("^L1 .* RET 0 $");
-            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
+            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
                 .shouldPassWith("^^L1 .* RET 0 $$");
-            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Error.Mod"))
+            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Error.Mod"))
                 .shouldFailWith("^info: errors detected: 31$");
         }
     }
@@ -55,17 +55,17 @@ unittest
         run!"./gamma --space example/type-check.eag --output-directory %s"(directory)
             .shouldPassWith("OberonOf grammar is single sweep");
 
-        run!"cd %s && ./OberonOa -t -v -w %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+        run!"cd %s && ./OberonOa -v -w %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
             .shouldPassWith("OberonOa compiler: compiling...");
-        run!"cd %s && ./OberonOb -t -v -w OberonOa.Out"(directory)
+        run!"cd %s && ./OberonOb -v -w OberonOa.Out"(directory)
             .shouldPassWith("OberonOb compiler: compiling...");
-        run!"cd %s && ./OberonOc -t -v -w OberonOb.Out"(directory)
+        run!"cd %s && ./OberonOc -v -w OberonOb.Out"(directory)
             .shouldPassWith("OberonOc compiler: compiling...");
-        run!"cd %s && ./OberonOd -t -v -w OberonOc.Out"(directory)
+        run!"cd %s && ./OberonOd -v -w OberonOc.Out"(directory)
             .shouldPassWith("OberonOd compiler: compiling...");
-        run!"cd %s && ./OberonOe -t -v -w OberonOd.Out"(directory)
+        run!"cd %s && ./OberonOe -v -w OberonOd.Out"(directory)
             .shouldPassWith("OberonOe compiler: compiling...");
-        run!"cd %s && ./OberonOf -t -v -w OberonOe.Out"(directory)
+        run!"cd %s && ./OberonOf -v -w OberonOe.Out"(directory)
             .shouldPassWith("OberonOf compiler: compiling...");
         run!"cd %s && cat OberonOf.Out"(directory)
             .shouldPassWith("ID M u l t i p l y PROC");

--- a/test/oberon0.d
+++ b/test/oberon0.d
@@ -11,11 +11,11 @@ unittest
     {
         run!"./gamma example/frontend.eag --output-directory %s"(directory)
             .shouldPassWith("OberonO grammar is SLAG");
-        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
             .shouldPassWith("^done$");
-        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
+        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
             .shouldPassWith("^done$");
-        run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Error.Mod"))
+        run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Error.Mod"))
             .shouldFailWith("^info: errors detected: 31$");
     }
 }
@@ -28,11 +28,11 @@ static foreach (eag; ["oberon0.eag", "unequal.eag"])
         {
             run!"./gamma --space example/%s --output-directory %s"(eag, directory)
                 .shouldPassWith("OberonO grammar is SLAG");
-            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
                 .shouldPassWith("^L1 .* RET 0 $");
-            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
+            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/BigSample.Mod"))
                 .shouldPassWith("^^L1 .* RET 0 $$");
-            run!"cd %s && ./OberonO %s"(directory, absolutePath("test/oberon0/Error.Mod"))
+            run!"cd %s && ./OberonO -t %s"(directory, absolutePath("test/oberon0/Error.Mod"))
                 .shouldFailWith("^info: errors detected: 31$");
         }
     }
@@ -55,17 +55,17 @@ unittest
         run!"./gamma --space example/type-check.eag --output-directory %s"(directory)
             .shouldPassWith("OberonOf grammar is single sweep");
 
-        run!"cd %s && ./OberonOa -v -w %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
+        run!"cd %s && ./OberonOa -t -v -w %s"(directory, absolutePath("test/oberon0/Sample.Mod"))
             .shouldPassWith("OberonOa compiler: compiling...");
-        run!"cd %s && ./OberonOb -v -w OberonOa.Out"(directory)
+        run!"cd %s && ./OberonOb -t -v -w OberonOa.Out"(directory)
             .shouldPassWith("OberonOb compiler: compiling...");
-        run!"cd %s && ./OberonOc -v -w OberonOb.Out"(directory)
+        run!"cd %s && ./OberonOc -t -v -w OberonOb.Out"(directory)
             .shouldPassWith("OberonOc compiler: compiling...");
-        run!"cd %s && ./OberonOd -v -w OberonOc.Out"(directory)
+        run!"cd %s && ./OberonOd -t -v -w OberonOc.Out"(directory)
             .shouldPassWith("OberonOd compiler: compiling...");
-        run!"cd %s && ./OberonOe -v -w OberonOd.Out"(directory)
+        run!"cd %s && ./OberonOe -t -v -w OberonOd.Out"(directory)
             .shouldPassWith("OberonOe compiler: compiling...");
-        run!"cd %s && ./OberonOf -v -w OberonOe.Out"(directory)
+        run!"cd %s && ./OberonOf -t -v -w OberonOe.Out"(directory)
             .shouldPassWith("OberonOf compiler: compiling...");
         run!"cd %s && cat OberonOf.Out"(directory)
             .shouldPassWith("ID M u l t i p l y PROC");

--- a/test/oberon0/BigSample.Mod
+++ b/test/oberon0/BigSample.Mod
@@ -1718,6 +1718,7 @@ MODULE BigSample;
 
 END BigSample.
 
+(*
 OSP.Compile @
 OSP.Decode
 OSP.Load
@@ -1725,3 +1726,4 @@ OSP.Exec Multiply 47 11
 OSP.Exec Divide 47 11
 OSP.Exec BinSearch 5  1 3 5 7 9  4
 OSP.Exec BinSearch 5  1 3 5 7 9  5
+*)

--- a/test/oberon0/Sample.Mod
+++ b/test/oberon0/Sample.Mod
@@ -43,6 +43,7 @@ MODULE Sample;
 
 END Sample.
 
+(*
 OSP.Compile @
 OSP.Decode
 OSP.Load
@@ -50,3 +51,4 @@ OSP.Exec Multiply 47 11
 OSP.Exec Divide 47 11
 OSP.Exec BinSearch 5  1 3 5 7 9  4
 OSP.Exec BinSearch 5  1 3 5 7 9  5
+*)


### PR DESCRIPTION
Made the old behavior for Oberon2 which allows arbitrary trailing content before EOF optional and the new behavior the default.
The option of allowing arbitrary content can be enabled by passing the command line option '-t' to the generated compiler.
This solves GH issue #11.